### PR TITLE
contents/en/examples/index: add link to examples folder in source code

### DIFF
--- a/contents/en/examples/index.html
+++ b/contents/en/examples/index.html
@@ -1,4 +1,5 @@
 <h1>Examples</h1>
+<p>In addition to the examples below, more can be found in the <a href="https://github.com/hajimehoshi/ebiten/tree/main/examples">examples directory</a>. For a curated list of open source frameworks, libraries, and software using Ebitengine, check out <a href="https://github.com/sedyh/awesome-ebiten">The Awesome Ebiten repository</a>.</p>
 <h2>Graphics (Basic)</h2>
 <div class="grid-container">
   <div class="grid-item-1">
@@ -170,7 +171,6 @@
     <p class="img thumbnail"><a href="flappy.html"><img src="/images/examples/flappy.png" width="400" height="300" alt="Flappy"></a></p>
   </div>
 </div>
-<p>Looking for more examples? <a href="https://github.com/sedyh/awesome-ebiten">The Awesome Ebiten repository</a> links to open source games powered by Ebiten.</p>
 <script>
   window.addEventListener('DOMContentLoaded', () => {
       setTOCLevel(2);


### PR DESCRIPTION
Move the whole "Looking for more examples?" section from bottom to top of the page for better visibility.