### PR TITLE
contents/en/documents/performancetips: update deprecated audio function

### DIFF
--- a/contents/en/documents/performancetips.html
+++ b/contents/en/documents/performancetips.html
@@ -54,11 +54,11 @@ B.DrawImage(A, op) // cyclic drawing! Avoid this if possible.</code></pre>
 <p>Creating an <code><a href="https://pkg.go.dev/github.com/hajimehoshi/ebiten/v2/audio#Player">audio.Player</a></code> is not expensive. It is fine to create one player for one short sound effect. For example, this code is totally fine:</p>
 <pre><code>// PlaySE plays a sound effect.
 func PlaySE(bs []byte) {
-    sePlayer := audio.NewPlayerFromBytes(audioContext, bs)
+    sePlayer := audioContext.NewPlayerFromBytes(bs)
     // sePlayer is never GCed as long as it plays.
     sePlayer.Play()
 }</code></pre>
-<p>In this code, <code><a href="https://pkg.go.dev/github.com/hajimehoshi/ebiten/v2/audio#NewPlayerFromBytes">audio.NewPlayerFromBytes</a></code> is used instead of <code><a href="https://pkg.go.dev/github.com/hajimehoshi/ebiten/v2/audio#NewPlayer">audio.NewPlayer</a></code>. <code>audio.NewPlayerFromBytes</code> creates a new stream on call, while <code>audio.NewPlayer</code> accepts an existing stream. As a stream has a byte data and its position, one stream cannot be shared by multiple players. With <code>NewPlayerFromBytes</code>, you can play sounds effects regardless of whether the same sound is playing or not.</p>
+<p>In this code, <code><a href="https://pkg.go.dev/github.com/hajimehoshi/ebiten/v2/audio#Context.NewPlayerFromBytes">(*audio.Context).NewPlayerFromBytes</a></code> is used instead of <code><a href="https://pkg.go.dev/github.com/hajimehoshi/ebiten/v2/audio#Context.NewPlayer">(*audio.Context).NewPlayer</a></code>. <code>(*audio.Context).NewPlayerFromBytes</code> creates a new stream on call, while <code>(*audio.Context).NewPlayer</code> accepts an existing stream. As a stream has a byte data and its position, one stream cannot be shared by multiple players. With <code>(*audio.Context).NewPlayerFromBytes</code>, you can play sounds effects regardless of whether the same sound is playing or not.</p>
 <p>As for BGMs that bytes can be much bigger than SEs, it is recommended to reuse one <code>audio.Player</code> by, e.g., <code><a href="https://pkg.go.dev/github.com/hajimehoshi/ebiten/v2/audio#Player.Rewind">(*audio.Player).Rewind</a></code>. It is because preparing a byte slice for the whole music at one time might be expensive. It should be rare to play the same BGM at the same time anyway.</p>
 <h2>Encourage using the discrete GPU on Windows</h2>
 <p>On Windows, you can encourage your application to use the discrete GPU instead of the integrated GPU by exporting some symbols: <code>NvOptimusEnablement</code> and <code>AmdPowerXpressRequestHighPerformance</code>. This requires <a href="https://golang.org/cmd/cgo/">Cgo</a> unfortunately, then Ebitengine does not do this by default.</p>


### PR DESCRIPTION
Thank you for always maintaining this project.

I noticed that the page https://ebitengine.org/en/documents/performancetips.html#It_is_fine_to_create_one_player_for_one_short_sound_effect uses deprecated functions ( `audio.NewPlayer`, `audio.NewPlayerFromBytes` ). This PR replaces these functions with the current recommended methods (` (*audio.Context).NewPlayer`,  `(*audio.Context).NewPlayerFromBytes` ).

