### PR TITLE
Fixed Fedora installation dependencies based on Fedora 42 inspection

### DIFF
--- a/contents/en/documents/install.html
+++ b/contents/en/documents/install.html
@@ -44,7 +44,7 @@
     <h3>Debian / Ubuntu</h3>
     <pre><code>sudo apt install libc6-dev libgl1-mesa-dev libxcursor-dev libxi-dev libxinerama-dev libxrandr-dev libxxf86vm-dev libasound2-dev pkg-config</code></pre>
     <h3>Fedora</h3>
-    <pre><code>sudo dnf install mesa-libGL-devel mesa-libGLES-devel libXrandr-devel libXcursor-devel libXinerama-devel libXi-devel libXxf86vm-devel alsa-lib-devel pkg-config</code></pre>
+    <pre><code>sudo dnf install libglvnd-devel libXrandr-devel libXcursor-devel libXinerama-devel libXi-devel libXxf86vm-devel alsa-lib-devel pkg-config</code></pre>
     <h3>Solus</h3>
     <pre><code>sudo eopkg install libglvnd-devel libx11-devel libxrandr-devel libxinerama-devel libxcursor-devel libxi-devel libxxf86vm-devel alsa-lib-devel pkg-config</code></pre>
     <h3>Arch</h3>

--- a/contents/ja/documents/install.html
+++ b/contents/ja/documents/install.html
@@ -44,7 +44,7 @@
     <h3>Debian / Ubuntu</h3>
     <pre><code>sudo apt install libc6-dev libgl1-mesa-dev libgl1-mesa-dev libxcursor-dev libxi-dev libxinerama-dev libxrandr-dev libxxf86vm-dev libasound2-dev pkg-config</code></pre>
     <h3>Fedora</h3>
-    <pre><code>sudo dnf install mesa-libGL-devel mesa-libGLES-devel libXrandr-devel libXcursor-devel libXinerama-devel libXi-devel libXxf86vm-devel alsa-lib-devel pkg-config</code></pre>
+    <pre><code>sudo dnf install libglvnd-devel libXrandr-devel libXcursor-devel libXinerama-devel libXi-devel libXxf86vm-devel alsa-lib-devel pkg-config</code></pre>
     <h3>Solus</h3>
     <pre><code>sudo eopkg install libglvnd-devel libx11-devel libxrandr-devel libxinerama-devel libxcursor-devel libxi-devel libxxf86vm-devel alsa-lib-devel pkg-config</code></pre>
     <h3>Arch</h3>


### PR DESCRIPTION
Changes:

* Remove `mesa-libGLES-devel` package. The latest version of Fedora 42 does not have any packages named mesa-libGLES.

    ```console
    $ LANG=C.UTF-8 dnf info --available 'mesa-libGLES*.x86_64' | grep Name
    Updating and loading repositories:
    Repositories loaded.
    No matching packages to list
    
    $ LANG=C.UTF-8 dnf info --available 'mesa-libGL*.x86_64' | grep Name
    Updating and loading repositories:
    Repositories loaded.
    Name           : mesa-libGL
    Name           : mesa-libGL-devel
    Name           : mesa-libGLU
    Name           : mesa-libGLU-devel
    Name           : mesa-libGLw
    Name           : mesa-libGLw-devel
    ```

* Replaced `mesa-libGL-devel` with `libglvnd-devel`

    The glx.h file required by Ebitengine is included in the `libglvnd-devel` package.
    
    ```console
    $ LANG=C.UTF-8 dnf repoquery --available --arch=x86_64 --file /usr/include/GL/glx.h
    Updating and loading repositories:
    Repositories loaded.
    libglvnd-devel-1:1.7.0-7.fc42.x86_64
    ```
    
    The `mesa-libGL-devel` package depends on the `libglvnd-devel` package.
    
    ```console
    $ LANG=C.UTF-8 dnf repoquery --available --arch=x86_64 --requires mesa-libGL-devel
    Updating and loading repositories:
    Repositories loaded.
    (mesa-libGL(x86-64) = 25.0.2-3.fc42 if mesa-libGL(x86-64))
    (mesa-libGL(x86-64) = 25.1.4-2.fc42 if mesa-libGL(x86-64))
    /usr/bin/pkg-config
    libglvnd-devel(x86-64) >= 1:1.3.2
    pkgconfig(libdrm) >= 2.4.121
    ```
    
    The files provided by the `mesa-libGL-devel` package do not seem to be necessary for Ebitengine.
    
    ```console
    $ LANG=C.UTF-8 dnf repoquery --available --arch=x86_64 --files mesa-libGL-devel
    Updating and loading repositories:
    Repositories loaded.
    /usr/include/GL
    /usr/include/GL/internal
    /usr/include/GL/internal/dri_interface.h
    /usr/lib64/pkgconfig/dri.pc
    ```

    I was able to build [a game using Ebitengine](https://github.com/koron/gopherrun) even on Fedora 42, which does not have the `mesa-libGL-devel` package installed.
    
     ```console
    $ LANG=C.UTF-8 dnf info --installed 'mesa-libGL*.x86_64' | grep Name
    Name            : mesa-libGL
    Name            : mesa-libGLU
    ```